### PR TITLE
EDA-161: Update Quarkus to 2.8 CR1 and Kotlin to 1.6.10

### DIFF
--- a/v1/services/EmailService/build.gradle.kts
+++ b/v1/services/EmailService/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-    kotlin("jvm") version "1.5.31"
-    kotlin("plugin.allopen") version "1.5.31"
+    kotlin("jvm") version "1.6.10"
+    kotlin("plugin.allopen") version "1.6.10"
     id("io.quarkus")
 }
 

--- a/v1/services/EmailService/gradle.properties
+++ b/v1/services/EmailService/gradle.properties
@@ -1,6 +1,6 @@
 #Gradle properties
 quarkusPluginId=io.quarkus
-quarkusPluginVersion=2.5.3.Final
+quarkusPluginVersion=2.8.0.CR1
 quarkusPlatformGroupId=io.quarkus.platform
 quarkusPlatformArtifactId=quarkus-bom
-quarkusPlatformVersion=2.5.3.Final
+quarkusPlatformVersion=2.8.0.CR1

--- a/v1/services/OrderService/build.gradle.kts
+++ b/v1/services/OrderService/build.gradle.kts
@@ -1,8 +1,8 @@
 plugins {
-    kotlin("jvm") version "1.5.31"
-    kotlin("plugin.allopen") version "1.5.31"
-    kotlin("plugin.noarg") version "1.5.31"
-    kotlin("plugin.jpa") version "1.5.31"
+    kotlin("jvm") version "1.6.10"
+    kotlin("plugin.allopen") version "1.6.10"
+    kotlin("plugin.noarg") version "1.6.10"
+    kotlin("plugin.jpa") version "1.6.10"
     id("io.quarkus")
 }
 

--- a/v1/services/OrderService/gradle.properties
+++ b/v1/services/OrderService/gradle.properties
@@ -1,6 +1,6 @@
 #Gradle properties
 quarkusPluginId=io.quarkus
-quarkusPluginVersion=2.5.3.Final
+quarkusPluginVersion=2.8.0.CR1
 quarkusPlatformGroupId=io.quarkus.platform
 quarkusPlatformArtifactId=quarkus-bom
-quarkusPlatformVersion=2.5.3.Final
+quarkusPlatformVersion=2.8.0.CR1

--- a/v1/services/PaymentService/build.gradle.kts
+++ b/v1/services/PaymentService/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-    kotlin("jvm") version "1.5.31"
-    kotlin("plugin.allopen") version "1.5.31"
+    kotlin("jvm") version "1.6.10"
+    kotlin("plugin.allopen") version "1.6.10"
     id("io.quarkus")
 }
 

--- a/v1/services/PaymentService/gradle.properties
+++ b/v1/services/PaymentService/gradle.properties
@@ -1,6 +1,6 @@
 #Gradle properties
 quarkusPluginId=io.quarkus
-quarkusPluginVersion=2.5.3.Final
+quarkusPluginVersion=2.8.0.CR1
 quarkusPlatformGroupId=io.quarkus.platform
 quarkusPlatformArtifactId=quarkus-bom
-quarkusPlatformVersion=2.5.3.Final
+quarkusPlatformVersion=2.8.0.CR1

--- a/v1/services/UserService/gradle.properties
+++ b/v1/services/UserService/gradle.properties
@@ -1,6 +1,6 @@
 #Gradle properties
 quarkusPluginId=io.quarkus
-quarkusPluginVersion=2.5.3.Final
+quarkusPluginVersion=2.8.0.CR1
 quarkusPlatformGroupId=io.quarkus.platform
 quarkusPlatformArtifactId=quarkus-bom
-quarkusPlatformVersion=2.5.3.Final
+quarkusPlatformVersion=2.8.0.CR1

--- a/v1/services/WarehouseService/build.gradle.kts
+++ b/v1/services/WarehouseService/build.gradle.kts
@@ -1,8 +1,8 @@
 plugins {
-    kotlin("jvm") version "1.5.31"
-    kotlin("plugin.allopen") version "1.5.31"
-    kotlin("plugin.noarg") version "1.5.31"
-    kotlin("plugin.jpa") version "1.5.31"
+    kotlin("jvm") version "1.6.10"
+    kotlin("plugin.allopen") version "1.6.10"
+    kotlin("plugin.noarg") version "1.6.10"
+    kotlin("plugin.jpa") version "1.6.10"
     id("io.quarkus")
 }
 

--- a/v1/services/WarehouseService/gradle.properties
+++ b/v1/services/WarehouseService/gradle.properties
@@ -1,6 +1,6 @@
 #Gradle properties
 quarkusPluginId=io.quarkus
-quarkusPluginVersion=2.5.3.Final
+quarkusPluginVersion=2.8.0.CR1
 quarkusPlatformGroupId=io.quarkus.platform
 quarkusPlatformArtifactId=quarkus-bom
-quarkusPlatformVersion=2.5.3.Final
+quarkusPlatformVersion=2.8.0.CR1

--- a/v2/services/EmailService/build.gradle.kts
+++ b/v2/services/EmailService/build.gradle.kts
@@ -1,8 +1,8 @@
 plugins {
-    kotlin("jvm") version "1.5.31"
-    kotlin("plugin.allopen") version "1.5.31"
-    kotlin("plugin.noarg") version "1.5.31"
-    kotlin("plugin.jpa") version "1.5.31"
+    kotlin("jvm") version "1.6.10"
+    kotlin("plugin.allopen") version "1.6.10"
+    kotlin("plugin.noarg") version "1.6.10"
+    kotlin("plugin.jpa") version "1.6.10"
     id("org.jlleitschuh.gradle.ktlint") version "10.2.0"
     id("io.quarkus")
 }

--- a/v2/services/EmailService/gradle.properties
+++ b/v2/services/EmailService/gradle.properties
@@ -1,6 +1,6 @@
 #Gradle properties
 quarkusPluginId=io.quarkus
-quarkusPluginVersion=2.5.3.Final
+quarkusPluginVersion=2.8.0.CR1
 quarkusPlatformGroupId=io.quarkus.platform
 quarkusPlatformArtifactId=quarkus-bom
-quarkusPlatformVersion=2.5.3.Final
+quarkusPlatformVersion=2.8.0.CR1

--- a/v2/services/OrderService/build.gradle.kts
+++ b/v2/services/OrderService/build.gradle.kts
@@ -1,8 +1,8 @@
 plugins {
-    kotlin("jvm") version "1.5.31"
-    kotlin("plugin.allopen") version "1.5.31"
-    kotlin("plugin.noarg") version "1.5.31"
-    kotlin("plugin.jpa") version "1.5.31"
+    kotlin("jvm") version "1.6.10"
+    kotlin("plugin.allopen") version "1.6.10"
+    kotlin("plugin.noarg") version "1.6.10"
+    kotlin("plugin.jpa") version "1.6.10"
     id("org.jlleitschuh.gradle.ktlint") version "10.2.0"
     id("io.quarkus")
 }

--- a/v2/services/OrderService/gradle.properties
+++ b/v2/services/OrderService/gradle.properties
@@ -1,6 +1,6 @@
 #Gradle properties
 quarkusPluginId=io.quarkus
-quarkusPluginVersion=2.5.3.Final
+quarkusPluginVersion=2.8.0.CR1
 quarkusPlatformGroupId=io.quarkus.platform
 quarkusPlatformArtifactId=quarkus-bom
-quarkusPlatformVersion=2.5.3.Final
+quarkusPlatformVersion=2.8.0.CR1

--- a/v2/services/PaymentService/build.gradle.kts
+++ b/v2/services/PaymentService/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-    kotlin("jvm") version "1.5.31"
-    kotlin("plugin.allopen") version "1.5.31"
+    kotlin("jvm") version "1.6.10"
+    kotlin("plugin.allopen") version "1.6.10"
     id("org.jlleitschuh.gradle.ktlint") version "10.2.0"
     id("io.quarkus")
 }

--- a/v2/services/PaymentService/gradle.properties
+++ b/v2/services/PaymentService/gradle.properties
@@ -1,6 +1,6 @@
 #Gradle properties
 quarkusPluginId=io.quarkus
-quarkusPluginVersion=2.5.3.Final
+quarkusPluginVersion=2.8.0.CR1
 quarkusPlatformGroupId=io.quarkus.platform
 quarkusPlatformArtifactId=quarkus-bom
-quarkusPlatformVersion=2.5.3.Final
+quarkusPlatformVersion=2.8.0.CR1

--- a/v2/services/UserService/gradle.properties
+++ b/v2/services/UserService/gradle.properties
@@ -1,6 +1,6 @@
 #Gradle properties
 quarkusPluginId=io.quarkus
-quarkusPluginVersion=2.5.3.Final
+quarkusPluginVersion=2.8.0.CR1
 quarkusPlatformGroupId=io.quarkus.platform
 quarkusPlatformArtifactId=quarkus-bom
-quarkusPlatformVersion=2.5.3.Final
+quarkusPlatformVersion=2.8.0.CR1

--- a/v2/services/WarehouseService/build.gradle.kts
+++ b/v2/services/WarehouseService/build.gradle.kts
@@ -1,8 +1,8 @@
 plugins {
-    kotlin("jvm") version "1.5.31"
-    kotlin("plugin.allopen") version "1.5.31"
-    kotlin("plugin.noarg") version "1.5.31"
-    kotlin("plugin.jpa") version "1.5.31"
+    kotlin("jvm") version "1.6.10"
+    kotlin("plugin.allopen") version "1.6.10"
+    kotlin("plugin.noarg") version "1.6.10"
+    kotlin("plugin.jpa") version "1.6.10"
     id("org.jlleitschuh.gradle.ktlint") version "10.2.0"
     id("io.quarkus")
 }

--- a/v2/services/WarehouseService/gradle.properties
+++ b/v2/services/WarehouseService/gradle.properties
@@ -1,6 +1,6 @@
 #Gradle properties
 quarkusPluginId=io.quarkus
-quarkusPluginVersion=2.5.3.Final
+quarkusPluginVersion=2.8.0.CR1
 quarkusPlatformGroupId=io.quarkus.platform
 quarkusPlatformArtifactId=quarkus-bom
-quarkusPlatformVersion=2.5.3.Final
+quarkusPlatformVersion=2.8.0.CR1

--- a/v3/services/EmailService/build.gradle.kts
+++ b/v3/services/EmailService/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-    kotlin("jvm") version "1.5.31"
-    kotlin("plugin.allopen") version "1.5.31"
+    kotlin("jvm") version "1.6.10"
+    kotlin("plugin.allopen") version "1.6.10"
     id("org.jlleitschuh.gradle.ktlint") version "10.2.0"
     id("io.quarkus")
 }

--- a/v3/services/EmailService/gradle.properties
+++ b/v3/services/EmailService/gradle.properties
@@ -1,6 +1,6 @@
 #Gradle properties
 quarkusPluginId=io.quarkus
-quarkusPluginVersion=2.6.1.Final
+quarkusPluginVersion=2.8.0.CR1
 quarkusPlatformGroupId=io.quarkus.platform
 quarkusPlatformArtifactId=quarkus-bom
-quarkusPlatformVersion=2.6.1.Final
+quarkusPlatformVersion=2.8.0.CR1

--- a/v3/services/OrderService/build.gradle.kts
+++ b/v3/services/OrderService/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-    kotlin("jvm") version "1.5.31"
-    kotlin("plugin.allopen") version "1.5.31"
+    kotlin("jvm") version "1.6.10"
+    kotlin("plugin.allopen") version "1.6.10"
     id("org.jlleitschuh.gradle.ktlint") version "10.2.0"
     id("io.quarkus")
 }

--- a/v3/services/OrderService/gradle.properties
+++ b/v3/services/OrderService/gradle.properties
@@ -1,6 +1,6 @@
 #Gradle properties
 quarkusPluginId=io.quarkus
-quarkusPluginVersion=2.6.1.Final
+quarkusPluginVersion=2.8.0.CR1
 quarkusPlatformGroupId=io.quarkus.platform
 quarkusPlatformArtifactId=quarkus-bom
-quarkusPlatformVersion=2.6.1.Final
+quarkusPlatformVersion=2.8.0.CR1

--- a/v3/services/PaymentService/build.gradle.kts
+++ b/v3/services/PaymentService/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-    kotlin("jvm") version "1.5.31"
-    kotlin("plugin.allopen") version "1.5.31"
+    kotlin("jvm") version "1.6.10"
+    kotlin("plugin.allopen") version "1.6.10"
     id("org.jlleitschuh.gradle.ktlint") version "10.2.0"
     id("io.quarkus")
 }

--- a/v3/services/PaymentService/gradle.properties
+++ b/v3/services/PaymentService/gradle.properties
@@ -1,6 +1,6 @@
 #Gradle properties
 quarkusPluginId=io.quarkus
-quarkusPluginVersion=2.6.1.Final
+quarkusPluginVersion=2.8.0.CR1
 quarkusPlatformGroupId=io.quarkus.platform
 quarkusPlatformArtifactId=quarkus-bom
-quarkusPlatformVersion=2.6.1.Final
+quarkusPlatformVersion=2.8.0.CR1

--- a/v3/services/TransformerService/build.gradle.kts
+++ b/v3/services/TransformerService/build.gradle.kts
@@ -1,8 +1,8 @@
 plugins {
-    kotlin("jvm") version "1.5.31"
-    kotlin("plugin.allopen") version "1.5.31"
-    kotlin("plugin.noarg") version "1.5.31"
-    kotlin("plugin.jpa") version "1.5.31"
+    kotlin("jvm") version "1.6.10"
+    kotlin("plugin.allopen") version "1.6.10"
+    kotlin("plugin.noarg") version "1.6.10"
+    kotlin("plugin.jpa") version "1.6.10"
     id("io.quarkus")
 }
 

--- a/v3/services/TransformerService/gradle.properties
+++ b/v3/services/TransformerService/gradle.properties
@@ -1,6 +1,6 @@
 #Gradle properties
 quarkusPluginId=io.quarkus
-quarkusPluginVersion=2.6.1.Final
+quarkusPluginVersion=2.8.0.CR1
 quarkusPlatformGroupId=io.quarkus.platform
 quarkusPlatformArtifactId=quarkus-bom
-quarkusPlatformVersion=2.6.1.Final
+quarkusPlatformVersion=2.8.0.CR1

--- a/v3/services/UserService/gradle.properties
+++ b/v3/services/UserService/gradle.properties
@@ -1,6 +1,6 @@
 #Gradle properties
 quarkusPluginId=io.quarkus
-quarkusPluginVersion=2.6.1.Final
+quarkusPluginVersion=2.8.0.CR1
 quarkusPlatformGroupId=io.quarkus.platform
 quarkusPlatformArtifactId=quarkus-bom
-quarkusPlatformVersion=2.6.1.Final
+quarkusPlatformVersion=2.8.0.CR1

--- a/v3/services/WarehouseService/build.gradle.kts
+++ b/v3/services/WarehouseService/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-    kotlin("jvm") version "1.5.31"
-    kotlin("plugin.allopen") version "1.5.31"
+    kotlin("jvm") version "1.6.10"
+    kotlin("plugin.allopen") version "1.6.10"
     id("org.jlleitschuh.gradle.ktlint") version "10.2.0"
     id("io.quarkus")
 }

--- a/v3/services/WarehouseService/gradle.properties
+++ b/v3/services/WarehouseService/gradle.properties
@@ -1,6 +1,6 @@
 #Gradle properties
 quarkusPluginId=io.quarkus
-quarkusPluginVersion=2.6.1.Final
+quarkusPluginVersion=2.8.0.CR1
 quarkusPlatformGroupId=io.quarkus.platform
 quarkusPlatformArtifactId=quarkus-bom
-quarkusPlatformVersion=2.6.1.Final
+quarkusPlatformVersion=2.8.0.CR1


### PR DESCRIPTION
Updating Quarkus to 2.8 CR1 to be able to use coroutines with quarkus kafka